### PR TITLE
Fix echo_get_status() not returning ECHO_STAT_PCM, DIRBUSY or BUSY correctly

### DIFF
--- a/c/echo.c
+++ b/c/echo.c
@@ -426,8 +426,8 @@ uint16_t echo_get_status(void) {
    // Look-up tables used to work around the fact that playing/stopping
    // won't set the status immediately (only when Echo processes the command)
    // and this can catch programmers off guard
-   static const uint8_t and_flags[] = {
-      0xFF,0xFF, 0xFF,0xFE,0xFF,0xFD, 0xFF,0xFF,0xFF
+   static const uint16_t and_flags[] = {
+      0xFFFF,0xFFFF, 0xFFFF,0xFFFE,0xFFFF,0xFFFD, 0xFFFF,0xFFFF,0xFFFF
    };
    static const uint8_t or_flags[] = {
       0x00,0x00, 0x01,0x00,0x02,0x00, 0x00,0x00,0x00

--- a/src-68k/echo.68k
+++ b/src-68k/echo.68k
@@ -470,15 +470,15 @@ Echo_GetStatus:
     
     move.b  ($A01FFF), d1           ; Get next pending command (if any)
     beq.s   @QueueChecked           ; No commands left to process?
-    move.b  (a1,d1.w), d2           ; Get mask of flags to leave
-    and.b   d2, d0                  ; Remove flags that should be clear
+    move.w  (a1,d1.w), d2           ; Get mask of flags to leave
+    and.w   d2, d0                  ; Remove flags that should be clear
     move.b  @OrTable-@AndTable(a1,d1.w), d2 ; Get mask of flags to set
     or.b    d2, d0                  ; Insert flags that should be set
 
     move.b  ($A01FFB), d1           ; Repeat that with 2nd pending command
     beq.s   @QueueChecked
-    move.b  (a1,d1.w), d2
-    and.b   d2, d0
+    move.w  (a1,d1.w), d2
+    and.w   d2, d0
     move.b  @OrTable-@AndTable(a1,d1.w), d2
     or.b    d2, d0
 
@@ -495,8 +495,8 @@ Echo_GetStatus:
 ; Every byte represents a possible command.
 ;----------------------------------------------------------------------------
 
-@AndTable:  dc.b $FF,$FF, $FF,$FE,$FF,$FD, $FF,$FF,$FF
-@OrTable:   dc.b $00,$00, $01,$00,$02,$00, $00,$00,$00
+@AndTable:  dc.w $FFFF,$FFFF,$FFFF,$FFFE,$FFFF,$FFFD,$FFFF,$FFFF,$FFFF
+@OrTable:   dc.b $00,$00,$01,$00,$02,$00,$00,$00,$00
             even
 
 ;****************************************************************************

--- a/src-68k/echo.68k
+++ b/src-68k/echo.68k
@@ -470,15 +470,15 @@ Echo_GetStatus:
     
     move.b  ($A01FFF), d1           ; Get next pending command (if any)
     beq.s   @QueueChecked           ; No commands left to process?
-    move.w  (a1,d1.w), d2           ; Get mask of flags to leave
-    and.w   d2, d0                  ; Remove flags that should be clear
+    move.b  (a1,d1.w), d2           ; Get mask of flags to leave
+    and.b   d2, d0                  ; Remove flags that should be clear
     move.b  @OrTable-@AndTable(a1,d1.w), d2 ; Get mask of flags to set
     or.b    d2, d0                  ; Insert flags that should be set
 
     move.b  ($A01FFB), d1           ; Repeat that with 2nd pending command
     beq.s   @QueueChecked
-    move.w  (a1,d1.w), d2
-    and.w   d2, d0
+    move.b  (a1,d1.w), d2
+    and.b   d2, d0
     move.b  @OrTable-@AndTable(a1,d1.w), d2
     or.b    d2, d0
 
@@ -495,8 +495,8 @@ Echo_GetStatus:
 ; Every byte represents a possible command.
 ;----------------------------------------------------------------------------
 
-@AndTable:  dc.w $FFFF,$FFFF,$FFFF,$FFFE,$FFFF,$FFFD,$FFFF,$FFFF,$FFFF
-@OrTable:   dc.b $00,$00,$01,$00,$02,$00,$00,$00,$00
+@AndTable:  dc.b $FF,$FF, $FF,$FE,$FF,$FD, $FF,$FF,$FF
+@OrTable:   dc.b $00,$00, $01,$00,$02,$00, $00,$00,$00
             even
 
 ;****************************************************************************


### PR DESCRIPTION
I believe there's a bug in `echo_get_status()` C API which is causing the function to never return ECHO_STAT_PCM, DIRBUSY or BUSY. The problem is in this bit of code:

```
   static const uint8_t and_flags[] = {
      0xFF,0xFF, 0xFF,0xFE,0xFF,0xFD, 0xFF,0xFF,0xFF
   };
   ...
   uint16_t status = 0;
   ...

   uint8_t command = z80_ram[0x1FFF];
   status &= and_flags[command];
   ...
   command = z80_ram[0x1FFB];
   status &= and_flags[command];
   ...
```

Status is a 16-bit integer, but the `and_flags` array returns a 8-bit mask. AND'ing these together truncates the value to 8-bit, stripping the upper byte's status.

Looking at the code, I believe the problem also occurs in the 68000 API, although I was not able to verify this as I do not use it.